### PR TITLE
Complete CfP before announcement

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,29 +24,20 @@
           <p>
             <a href="https://www.w3.org/"><img alt="W3C" src=
             "media/w3c_home_nb-v.svg" height="48" width="72"></a>
-            <a href="https://www.smpte.org/"><img alt="W3C" src=
+            <a href="https://www.smpte.org/"><img alt="SMPTE" src=
             "media/smpte_logo.png" height="48"></a><span id=
         "translations"><a href="zh.index.html"><span lang="zh">中文</span></a></span>
           </p>
           <div class="banner-title">
             <h1>
-              <span class="todo">[PROPOSED]</span>
-              <br/>
               W3C/SMPTE Joint Workshop on Professional Media Production on the Web
             </h1>
           </div>
           <p class="attribution">
             <span>Timeline photo by <a href="https://unsplash.com/@kineticbear?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Jacob Miller</a> on <a href="https://unsplash.com/s/photos/timeline?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Unsplash</a></span>
           </p>
-          <p><span class="todo">9-18 November 2021 [TENTATIVE]</span>; online event</p>
+          <p>9-18 November 2021; online event</p>
         </div>
-      </div>
-      <div class="todo">
-        <p>
-          This is a draft Call for Participation for a possible but not yet
-          confirmed W3C/SMPTE joint workshop. This document may be updated, replaced or
-          obsoleted by other documents at any time.
-        </p>
       </div>
       <nav class="menu" id="menu">
         <ul>
@@ -84,12 +75,9 @@
       <h2 class="footnote">
         Important Dates
       </h2>
-      <p class="todo">
-        Important: Tentative schedule, dates will be adjusted as needed.
-      </p>
       <dl>
         <dt>As soon as possible</dt>
-        <dd>Submit a proposal for a talk</dd>
+        <dd><a href="speakers.html">Submit a proposal for a talk</a></dd>
 
         <dt>15 October 2021</dt>
         <dd>Deadline for selected speakers to provide their recorded talk</dd>
@@ -98,7 +86,7 @@
         <dd>Public release of all accepted talks</dd>
 
         <dt>5 November 2021</dt>
-        <dd>Deadline to register as workshop participant</dd>
+        <dd>Deadline to <a href="https://www.w3.org/2002/09/wbs/1/media-production-ws-2021/">register as workshop participant</a></dd>
 
         <dt>9-18 November 2021</dt>
         <dd>Four live sessions (1h30 each)
@@ -272,8 +260,8 @@
             The attendance is <b>free</b> for all invited participants and is open to the public, whether or not W3C/SMPTE members.
           </p>
           <p>
-            Please <strong class="todo"><a href="#">register for the
-            event</a></strong> before <span class="todo">5 November 2021</span> to
+            Please <strong><a href="https://www.w3.org/2002/09/wbs/1/media-production-ws-2021/">register for the
+            event</a></strong> before 5 November 2021 to
             be notified of the videos availability, of the forum set up to
             facilitate discussion among registered participants, and of the
             live sessions logistics. The Program Committee will only accept

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
             </li>
             <li>
               <b>Latency management</b> when operating on media assets stored
-              in the cloud trough a Web based interface, as well as in live
+              in the cloud through a Web based interface, as well as in live
               media production workflows.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
               for professional media production
             </li>
             <li>
-              Understand the unique peformance and format requirements of professional media production workflows
+              Understand the unique performance and format requirements of professional media production workflows
             </li>
             <li>
               Identify gaps in the web platform and standardization opportunities

--- a/index.html
+++ b/index.html
@@ -337,8 +337,18 @@
 
           <h3>Committee</h3>
           <ul>
+            <li>Paul Adenot (Mozilla)</li>
+            <li>James Cain (Grass Valley)</li>
+            <li>Steve Cronan (5th Kind)</li>
+            <li>Chris Cunningham (Google)</li>
             <li>François Daoust (W3C)</li>
-            <li><span class="todo">To be completed</span></li>
+            <li>Bruce Devlin (SMPTE)</li>
+            <li>Jim Helman (MovieLabs)</li>
+            <li>Paul Randall (AVID)</li>
+            <li>Steve Shapiro (Marvel Studios)</li>
+            <li>Kevin Streeter (Adobe)</li>
+            <li>Ke Wu (Tencent Video)</li>
+            <li>Song Xu (China Mobile Migu)</li>
           </ul>
         </section>
     </main>

--- a/speakers.html
+++ b/speakers.html
@@ -118,8 +118,8 @@
             <strong>as soon as possible</strong> and
             we will work with you in confirming and defining your proposed
             contribution. You may also
-            <span class="todo"><a href="mailto:fd@w3.org">contact the Program
-            Committee directly</a></span> at any time if you have any questions.
+            <a href="mailto:group-media-production-pc@w3.org">contact the
+            Program Committee directly</a> at any time if you have questions.
           </p>
         </section>
         <section id="why">

--- a/speakers.html
+++ b/speakers.html
@@ -18,28 +18,19 @@
           <p>
             <a href="https://www.w3.org/"><img alt="W3C" src=
             "media/w3c_home_nb-v.svg" height="48" width="72"></a>
-            <a href="https://www.smpte.org/"><img alt="W3C" src=
-            "media/smpte_logo.svg" height="48"></a>
+            <a href="https://www.smpte.org/"><img alt="SMPTE" src=
+            "media/smpte_logo.png" height="48"></a>
           </p>
           <div class="banner-title">
             <h1>
-              <span class="todo">[PROPOSED]</span>
-              <br/>
               W3C/SMPTE Joint Workshop on Professional Media Production on the Web
             </h1>
           </div>
           <p class="attribution">
             <span>Timeline photo by <a href="https://unsplash.com/@kineticbear?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Jacob Miller</a> on <a href="https://unsplash.com/s/photos/timeline?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Unsplash</a></span>
           </p>
-          <p><span class="todo">9-18 November 2021 [TENTATIVE]</span>; online event</p>
+          <p>9-18 November 2021; online event</p>
         </div>
-      </div>
-      <div class="todo">
-        <p>
-          This is a draft Call for Participation for a possible but not yet
-          confirmed W3C/SMPTE joint workshop. This document may be updated, replaced or
-          obsoleted by other documents at any time.
-        </p>
       </div>
       <nav class="menu" id="menu">
         <ul>
@@ -74,9 +65,6 @@
       <h2 class="footnote">
         Important Dates
       </h2>
-      <p class="todo">
-        Important: Tentative schedule, dates will be adjusted as needed.
-      </p>
       <dl>
         <dt>As soon as possible</dt>
         <dd>Submit a proposal for a talk</dd>
@@ -88,12 +76,31 @@
         <dd>Public release of all accepted talks</dd>
 
         <dt>5 November 2021</dt>
-        <dd>Deadline to register as workshop participant</dd>
+        <dd>Deadline to <a href="https://www.w3.org/2002/09/wbs/1/media-production-ws-2021/">register as workshop participant</a></dd>
 
         <dt>9-18 November 2021</dt>
         <dd>Four live sessions (1h30 each)
         <br/>part of SMPTE's ATC</dd>
       </dl>
+    </aside>
+    <aside class="box" id="submit-form">
+      <h2 class="footnote">
+        Submit a talk proposal
+      </h2>
+      <label for="speaker-name">Your name:</label>
+      <input id="speaker-name" placeholder="Your name" maxlength="64">
+
+      <label for="speaker-bio">Your bio:</label>
+      <input id="speaker-bio" placeholder="Your related experience or expertise" maxlength="64">
+
+      <label for="talk-title">Talk title:</label>
+      <input id="talk-title" placeholder="Your talk title" maxlength="64">
+
+      <label for="talk-abstract">Talk abstract:</label>
+      <textarea id="talk-abstract" placeholder="Summarize in a single paragraph the major aspects of the proposal you want to present." rows="3" maxlength="512"></textarea>
+
+      <button id="submit-button">Submit</button>
+      <small>(Submit opens a prepopulated mail compose window. You may customize your submission at this point before sending it.)</small>
     </aside>
     <main id="main" class="main">
       <section id="home">
@@ -193,7 +200,7 @@
             delivered as a combination of a slideset (in HTML or PDF) and a
             recorded audio or video of the speaker (<strong>without</strong>
             screen recording of the slides)
-            <span class="todo"><strong>before 15 October 2021</strong></span>.
+            <strong>before 15 October 2021</strong>.
           </p>
           <p>
             These two elements will then be synchronized and combined to allow
@@ -220,9 +227,10 @@
             way accessible to people with disabilities</a>.
           </p>
           <p>
-            Talks are expected to be delivered in English
-            <span class="todo">(TODO: figure out whether we may accept talks in
-            other languages, notably Chinese and Japanese?)</span>.
+            Talks are expected to be delivered in English. Please
+            <a href="mailto:group-media-production-pc@w3.org">contact the
+            Program Committee</a> if you would like to submit a talk in another
+            language.
           </p>
           <p>
             W3C will provide transcripts and captions for all the selected
@@ -272,5 +280,6 @@
       </p>
     </footer>
     <script src="script.js"></script>
+    <script src="submit.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -878,3 +878,19 @@ figure {
 dfn {
   font-weight: bolder;
 }
+
+label:before, label:after {
+  content: "\a";
+  white-space: pre;
+}
+
+input, textarea {
+  width: 100%;
+  font: .9em/1.1 Helvetica, Arial, Verdana, sans-serif;
+}
+
+button {
+  margin: 20px 0 0 0;
+  width: 100%;
+  height: 1.5rem;
+}

--- a/submit.js
+++ b/submit.js
@@ -1,0 +1,34 @@
+/*jshint esversion: 6 */
+(() => {
+    const button = document.querySelector('#submit-button');
+    if (button) addSubmitButtonListener();
+
+    function addSubmitButtonListener() {
+        document.querySelector('#submit-button').onclick = () => {
+            const name = document.querySelector('#speaker-name').value;
+            const bio = document.querySelector('#speaker-bio').value;
+            const title = document.querySelector('#talk-title').value;
+            const abstract = document.querySelector('#talk-abstract').value;
+
+            const subject = `[workshop proposal] ${title}`;
+            const body = `Hi Program Committee,` +
+            `\n\n` +
+            `I would like to submit a talk proposal for the W3C/SMPTE Workshop on Professional Media Production on the Web.` +
+            `\n\n` +
+            `Name: ${name}` +
+            `\n\n` +
+            `Bio: ${bio}` +
+            `\n\n` +
+            `Talk title: ${title}` +
+            `\n\n` +
+            `Talk abstract: ${abstract}`+
+            `\n\n` +
+            `Best regards,\n${name}`;
+
+            window.location.href =
+                'mailto:group-media-production-pc@w3.org' +
+                '?subject=' + encodeURIComponent(subject) +
+                '&body=' + encodeURIComponent(body);
+        };
+    }
+})();

--- a/zh.index.html
+++ b/zh.index.html
@@ -258,8 +258,16 @@
 
           <h3>组委会</h3>
           <ul>
+            <li>Paul Adenot (Mozilla)</li>
+            <li>James Cain (Grass Valley)</li>
+            <li>Steve Cronan (5th Kind)</li>
+            <li>Chris Cunningham (Google)</li>
             <li>François Daoust (W3C)</li>
-            <li><span class="todo">待定</span></li>
+            <li>Bruce Devlin (SMPTE)</li>
+            <li>Jim Helman (MovieLabs)</li>
+            <li>Paul Randall (AVID)</li>
+            <li>Steve Shapiro (Marvel Studios)</li>
+            <li>Kevin Streeter (Adobe)</li>
           </ul>
         </section>
     </main>

--- a/zh.index.html
+++ b/zh.index.html
@@ -30,21 +30,14 @@
           </p>
           <div class="banner-title">
             <h1>
-              <span class="todo">[提议]</span>
-              <br/>
               W3C/SMPTE 专业媒体制作 Web 技术联合研讨会
             </h1>
           </div>
           <p class="attribution">
             <span>题图来源于 <a href="https://unsplash.com/@kineticbear?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Jacob Miller</a> 发布在 <a href="https://unsplash.com/s/photos/timeline?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText">Unsplash</a></span>
           </p>
-          <p><span class="todo">2021年11月9-18日 [暂定]</span>; 线上会议</p>
+          <p>2021年11月9-18日; 线上会议</p>
         </div>
-      </div>
-      <div class="todo">
-        <p>
-          这是一份为筹备中但未确定的 W3C/SMPTE 联合研讨会征集参会者的倡议书。本文档可能随时被其它文档更新、替代或废弃。
-        </p>
       </div>
       <nav class="menu" id="menu">
         <ul>
@@ -81,12 +74,9 @@
       <h2 class="footnote">
         重要日期
       </h2>
-      <p class="todo">
-        重要提示: 计划暂定，日期会根据需求随时调整。
-      </p>
       <dl>
         <dt>及早</dt>
-        <dd>提交演讲</dd>
+        <dd><a href="speakers.html">提交演讲</a></dd>
 
         <dt>2021年10月15日</dt>
         <dd>被选中讲者提供他们的录制演讲的截止日期</dd>
@@ -95,7 +85,7 @@
         <dd>公布所有已接受的演讲内容</dd>
 
         <dt>2021年11月5日</dt>
-        <dd>研讨会参与者注册的截止日期</dd>
+        <dd><a href="https://www.w3.org/2002/09/wbs/1/media-production-ws-2021/">研讨会参与者注册</a>的截止日期</dd>
 
         <dt>2021年11月9-18日</dt>
         <dd>四个线上讨论 (每个时长1小时30分钟)
@@ -214,7 +204,7 @@
           </h2>
           <p>研讨会对公众开放，不限于 W3C/SMPTE 会员。所有受邀人员均可<b>免费</b>参会。
           </p>
-          <p>请在2021年11月05日前<strong class="todo"><a href="#">注册报名</a></strong>参加活动，以方便项目委员会获知视频的可用性、为注册参与者讨论而设立论坛，以及2020年9月现场会议的后勤安排。项目委员会只接受报名资料与研讨会主题相关的参加者。
+          <p>请在2021年11月05日前<strong><a href="https://www.w3.org/2002/09/wbs/1/media-production-ws-2021/">注册报名</a></strong>参加活动，以方便项目委员会获知视频的可用性、为注册参与者讨论而设立论坛，以及2020年9月现场会议的后勤安排。项目委员会只接受报名资料与研讨会主题相关的参加者。
           </p>
           <p>
             包括本次研讨会在内，W3C 所有会议均在 W3C 的


### PR DESCRIPTION
This update:
- fills the program committee
- adds the mailing-list to use to reach out to the program committee
- adds the speakers submission form
- adds the registration form (not yet open)
- drops occurrences of "draft", "tentative", etc. to officialize the CfP